### PR TITLE
Schedule attacker concept

### DIFF
--- a/src/main/scala/com/scoober/kafkascalalab/AttackProducer.scala
+++ b/src/main/scala/com/scoober/kafkascalalab/AttackProducer.scala
@@ -3,19 +3,24 @@ package com.scoober.kafkascalalab
 import java.util.Properties
 
 import akka.actor.{Actor, ActorLogging, Props}
-import com.scoober.kafkascalalab.AttackProducer.Shoot
+import com.scoober.kafkascalalab.AttackProducer.{Shoot, Stop}
 import org.apache.kafka.clients.producer.{KafkaProducer, ProducerRecord}
 
-object AttackProducer {
-  def props(power: Int): Props = Props(new AttackProducer(power))
+import scala.util.Random
 
-  final case class Shoot(power: Int)
+object AttackProducer {
+  def props(): Props = Props(new AttackProducer())
+
+  final case class Shoot()
+
+  final case class Stop()
 
 }
 
-class AttackProducer(power: Int) extends Actor with ActorLogging {
+class AttackProducer() extends Actor with ActorLogging {
 
-  def shoot(shootValue: Int) = {
+  def shoot() = {
+    //TODO move the producer create and destroy to specific methods and messages
     val props = new Properties()
     props.put("bootstrap.servers", "kafka:9092")
     props.put("client.id", "scala-lab-producer")
@@ -26,14 +31,16 @@ class AttackProducer(power: Int) extends Actor with ActorLogging {
 
     val TOPIC = "scala-pub"
 
-    val record = new ProducerRecord(TOPIC, "scala-shoot", s"$shootValue")
+    val record = new ProducerRecord(TOPIC, "scala-shoot", s"${Random.nextInt(10)}")
     producer.send(record)
     producer.close()
   }
 
   override def receive: Receive = {
-    case Shoot(shootValue) => {
-      shoot(shootValue)
+    case Shoot() =>
+      shoot()
+
+    case Stop() => {
       if (1 == 0)
         context.system.terminate()
     }

--- a/src/main/scala/com/scoober/kafkascalalab/Lab.scala
+++ b/src/main/scala/com/scoober/kafkascalalab/Lab.scala
@@ -21,8 +21,8 @@ class Lab extends Actor with ActorLogging {
   import context.dispatcher
 
   override def preStart(): Unit = {
-    val attackProducer = context.actorOf(AttackProducer.props(0))
-    context.system.scheduler.schedule(2.second, 200.microseconds, attackProducer, Shoot(7))
+    val attackProducer = context.actorOf(AttackProducer.props())
+    context.system.scheduler.schedule(2.second, 200.microseconds, attackProducer, Shoot())
   }
 
   override def receive: Receive = {


### PR DESCRIPTION
This `PR` focus on create a scheduler to shoot the opponent indefinitely until reach a certain amount of damage. The damage is not yet defined and probably will be implemented in a middleware piece of code, the frontend deciding the winner is being considered an option for simplicity. 