### PR TITLE
Unify topic for attacks

### DIFF
--- a/src/main/scala/com/scoober/kafkascalalab/AttackConsumer.scala
+++ b/src/main/scala/com/scoober/kafkascalalab/AttackConsumer.scala
@@ -47,7 +47,7 @@ class AttackConsumer extends Actor with ActorLogging {
     properties.put("auto.commit.interval.ms", "5000")
 
     val consumer: KafkaConsumer[String, String] = new KafkaConsumer(properties)
-    val topics = util.Arrays.asList("elixir-pub")
+    val topics = util.Arrays.asList("attacks")
 
     consumer.subscribe(topics)
 

--- a/src/main/scala/com/scoober/kafkascalalab/AttackConsumer.scala
+++ b/src/main/scala/com/scoober/kafkascalalab/AttackConsumer.scala
@@ -28,11 +28,15 @@ class AttackConsumer extends Actor with ActorLogging {
   }
 
   private def shooted(): Unit = {
-
     val msg = consumer.poll(Duration.of(200, ChronoUnit.MILLIS))
 
-    log.info("In total {}x messages were read", msg.count())
-    msg.iterator().forEachRemaining(m => log.info(m.value()))
+    msg.iterator().forEachRemaining(m => {
+      log.info("MESSAGE: {}", m)
+      if(m.key() == "elixir-pub")
+        log.info("message: {}", m)
+      else
+        log.info("I am not interested on my own messages: {}", m)
+    })
   }
 
   private def buildConsumer(): KafkaConsumer[String, String] = {
@@ -41,8 +45,6 @@ class AttackConsumer extends Actor with ActorLogging {
     properties.put("bootstrap.servers", "kafka:9092")
     properties.put("key.deserializer", "org.apache.kafka.common.serialization.StringDeserializer")
     properties.put("value.deserializer", "org.apache.kafka.common.serialization.StringDeserializer")
-    properties.put("key.serializer", "org.apache.kafka.common.serialization.StringSerializer")
-    properties.put("value.serializer", "org.apache.kafka.common.serialization.StringSerializer")
     properties.put("enable.auto.commit", "true")
     properties.put("auto.offset.reset", "latest")
     properties.put("auto.commit.interval.ms", "5000")
@@ -51,7 +53,6 @@ class AttackConsumer extends Actor with ActorLogging {
     val topics = util.Arrays.asList("attacks")
 
     consumer.subscribe(topics)
-
     consumer
   }
 }

--- a/src/main/scala/com/scoober/kafkascalalab/AttackConsumer.scala
+++ b/src/main/scala/com/scoober/kafkascalalab/AttackConsumer.scala
@@ -37,13 +37,14 @@ class AttackConsumer extends Actor with ActorLogging {
 
   private def buildConsumer(): KafkaConsumer[String, String] = {
     val properties: Properties = new Properties()
-    properties.put("group.id", "elixir-pub-consumer")
+    properties.put("group.id", "kafka-lab-scala-consumer")
     properties.put("bootstrap.servers", "kafka:9092")
     properties.put("key.deserializer", "org.apache.kafka.common.serialization.StringDeserializer")
     properties.put("value.deserializer", "org.apache.kafka.common.serialization.StringDeserializer")
     properties.put("key.serializer", "org.apache.kafka.common.serialization.StringSerializer")
     properties.put("value.serializer", "org.apache.kafka.common.serialization.StringSerializer")
     properties.put("enable.auto.commit", "true")
+    properties.put("auto.offset.reset", "latest")
     properties.put("auto.commit.interval.ms", "5000")
 
     val consumer: KafkaConsumer[String, String] = new KafkaConsumer(properties)

--- a/src/main/scala/com/scoober/kafkascalalab/AttackProducer.scala
+++ b/src/main/scala/com/scoober/kafkascalalab/AttackProducer.scala
@@ -31,7 +31,7 @@ class AttackProducer() extends Actor with ActorLogging {
     val msg = Random.nextInt(10)
     val record = new ProducerRecord("attacks", 1, "scala-pub", s"${msg}")
 
-    log.info("Preparing to publish a record: ", s"${msg}")
+    log.info("Preparing to publish a record: {}", s"${msg}")
 
     producer.send(record)
 

--- a/src/main/scala/com/scoober/kafkascalalab/AttackProducer.scala
+++ b/src/main/scala/com/scoober/kafkascalalab/AttackProducer.scala
@@ -29,13 +29,13 @@ class AttackProducer() extends Actor with ActorLogging {
 
   private def shoot() = {
     val msg = Random.nextInt(10)
-    val record = new ProducerRecord("attacks", 1, "scala-pub", s"${msg}")
+    val record = new ProducerRecord("attacks", 1, "scala-pub", s"$msg")
 
-    log.info("Preparing to publish a record: {}", s"${msg}")
+    log.info("Preparing to publish a record: {}", s"$msg")
 
     producer.send(record)
 
-    log.info("Published a shot with power {} to attacks topic", s"${msg}")
+    log.info("Published a shot with power {} to attacks topic", s"$msg")
   }
 
   private def buildKafkaProducer = {

--- a/src/main/scala/com/scoober/kafkascalalab/AttackProducer.scala
+++ b/src/main/scala/com/scoober/kafkascalalab/AttackProducer.scala
@@ -28,16 +28,20 @@ class AttackProducer() extends Actor with ActorLogging {
   }
 
   private def shoot() = {
-    val TOPIC = "scala-pub"
-    val record = new ProducerRecord(TOPIC, "scala-shoot", s"${Random.nextInt(10)}")
+    val msg = Random.nextInt(10)
+    val record = new ProducerRecord("attacks", 1, "scala-pub", s"${msg}")
+
+    log.info("Preparing to publish a record: ", s"${msg}")
 
     producer.send(record)
+
+    log.info("Published a shot with power {} to attacks topic", s"${msg}")
   }
 
   private def buildKafkaProducer = {
     val props = new Properties()
     props.put("bootstrap.servers", "kafka:9092")
-    props.put("client.id", "scala-lab-producer")
+    props.put("client.id", "kafka-lab-scala-producer")
     props.put("key.serializer", "org.apache.kafka.common.serialization.StringSerializer")
     props.put("value.serializer", "org.apache.kafka.common.serialization.StringSerializer")
 


### PR DESCRIPTION
Now all players will produce and consume attacks from same topic. It will allow - if desired - to have multiple game rooms without many changes in the code.
